### PR TITLE
Store root config in GLOBAL and LOCAL config dirs

### DIFF
--- a/goto.py
+++ b/goto.py
@@ -90,7 +90,7 @@ class Root(object):
         self.shortcuts = shortcuts
 
     @classmethod
-    def empty(cls, root="": str, config_filepath: str) -> "Root":
+    def empty(cls, root: str, config_filepath: str) -> "Root":
         root_obj = cls(
             root=root,
             path="",


### PR DESCRIPTION
### Documentation
Closes #4 

### Goal
- User can read from a global roots config that can be checked into source control and shared across machines.
- User can edit and create new roots in the global config
- User can maintain, edit, create local configs that are specific to the machine

### Changes
- Split config into GLOBAL_GOTO_DIR=~/.config/goto-global and LOCAL_GOTO_DIR=~/.config/goto-local
- Setup only populates LOCAL_GOTO_DIR
- GLOBAL_GOTO_DIR can be checked into VCS (e.g. using stow)
- The filepath of every Root object is baked into it at read/create time, so you can read/write any Root and just save it back to where it came from
- We read from both GLOBAL_GOTO_DIR/roots and LOCAL_GOTO_DIR/roots to find available roots
- Add a --use-global flag that you can pass when making a new root that says to make it in the GLOBAL dir rather than LOCAL