### PR TITLE
Use tmp file to communicate directory

### DIFF
--- a/goto
+++ b/goto
@@ -1,15 +1,20 @@
 #!/bin/bash
 
-output=$(goto.py "$@")
+# Create output file to store goto.py path output.
+tmpfile="$(mktemp)"
 
-# expand tilde
-output="${output/#\~/$HOME}"
+# Pass temp file to goto.py so it can store the path to cd to 
+# there. Any other output will just write to stdout.
+goto.py --temp-file "${tmpfile}" "$@"
 
-# go to directory if possible
-if [[ -d "$output" ]] ; then 
-    cd $output
+# Pull results from tmpfile and remove tmpfile.
+path="$(cat "${tmpfile}")"
+rm "${tmpfile}"
 
-# else print output as error condition
-else
-    echo "$output"
+# Expand tilde in output.
+path="${path/#\~/$HOME}"
+
+# Go to directory if possible.
+if [[ -d "${path}" ]] ; then 
+    cd "${path}"
 fi

--- a/goto.py
+++ b/goto.py
@@ -472,7 +472,10 @@ def main():
     # print roots mode
     elif args.roots:
         for root in roots.roots():
-            print(root)
+            if root == configs["current_root"]:
+                print(f"*{root}")
+            else:
+                print(root)
 
     # create new root mode
     elif args.new:

--- a/goto.py
+++ b/goto.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-
-"""command line utility to navigate file structure using bookmarks
+"""command line utility to navigate file structure using bookmarks.
 
 goto is a tool that allows you to quickly move between directories.
 The basic workflow is as follows:
@@ -59,6 +58,7 @@ LOCAL_ROOTS_DIR = path.join(LOCAL_GOTO_DIR, "roots")
 # Classes                                                                     #
 ###############################################################################
 
+
 class ArgumentParserError(Exception):
     pass
 
@@ -116,12 +116,12 @@ class Root(object):
                 root = Root(**json.load(f))
                 root.config_filepath = filepath
                 return root
-        except Exception as e:
+        except Exception:
             return None
 
     def write(self) -> None:
         with open(self.config_filepath, 'w') as f:
-                json.dump(self, f, **json_args(True))
+            json.dump(self, f, **json_args(True))
 
 
 class Roots(object):
@@ -191,9 +191,9 @@ class Roots(object):
             ]
 
         roots = {
-                root.root: root for root in
-                    (Root.read(f) for f in files)
-                if root is not None and root.root is not None
+            root.root: root for root in
+            (Root.read(f) for f in files)
+            if root is not None and root.root is not None
         }
 
         return Roots(roots)
@@ -213,6 +213,7 @@ def json_args(use_dict: bool):
         "sort_keys": True,
         "indent": "\t"
     }
+
 
 def get_parser(parser_type):
 
@@ -280,7 +281,7 @@ def parameters_from_args(args, configs):
 
 def set_current_root(new_root, roots, configs):
 
-    current_root=roots.name(configs["current_root"])
+    current_root = roots.name(configs["current_root"])
 
     if new_root in roots:
         configs["current_root"] = new_root
@@ -507,7 +508,7 @@ def main():
 
         # if shortcut not resolved, print error and exit
         else:
-            print(f"Shortcut not found in {roots[root].root}")
+            print(f"Shortcut missing in {roots[root].root}")
             exit_code = 1
 
     # no mode selected, print help

--- a/goto.py
+++ b/goto.py
@@ -262,6 +262,10 @@ def get_parser(parser_type):
                         help="create new roots in the GLOBAL dir",
                         action="store_true")
 
+    parser.add_argument("-t", "--temp-file",
+                        help="temp file to write path to",
+                        action="store")
+
     parser.add_argument("first", nargs='?', default="all")
     parser.add_argument("second", nargs='?')
     return parser
@@ -300,6 +304,13 @@ def load_file(filepath):
     with open(filepath) as the_file:
         return json.load(the_file)
 
+
+def print_path(path, temp_file):
+    if temp_file:
+        with open(temp_file, 'w') as f:
+            f.write(path)
+    else:
+        print(path)
 
 def print_information(print_arg, roots, configs):
 
@@ -507,7 +518,7 @@ def main():
 
         # name of path to change to; print this so bash can cd to it
         if full_path:
-            print(full_path)
+            print_path(full_path, args.temp_file)
 
         # if shortcut not resolved, print error and exit
         else:

--- a/goto.py
+++ b/goto.py
@@ -237,6 +237,10 @@ def get_parser(parser_type):
                        help="see available shortcuts for a root",
                        action="store_true")
 
+    group.add_argument("-r", "--roots",
+                       help="list roots",
+                       action="store_true")
+
     group.add_argument("-c", "--configs", "--config",
                        help="open config JSON",
                        action="store_true")
@@ -463,6 +467,11 @@ def main():
     elif args.all:
         all_shortcuts = all_print_information(args.first, roots, configs)
         print(all_shortcuts)
+
+    # print roots mode
+    elif args.roots:
+        for root in roots.roots():
+            print(root)
 
     # create new root mode
     elif args.new:


### PR DESCRIPTION
Adds a `--temp-file` flag that takes one argument. If you supply this flag, the directory to change to will be written to the specified tmp file rather than printed to stdout. All other output will still be directed to stdout.

The purpose of this is to establish a second channel of communication with the calling process. Now, the caller is safe to always print anything returned by `goto.py`'s stdout, while the caller can choose to `cd` to any directory written to the temp file.